### PR TITLE
Chatbox "T" fix

### DIFF
--- a/Client/Assets/game/chat.js
+++ b/Client/Assets/game/chat.js
@@ -903,13 +903,6 @@ class Chat {
         }
     }
 
-    updateTempMessages() {
-        const now = Date.now();
-        this.tempMessages = this.tempMessages.filter(
-            (msg) => now - msg.timestamp < this.messageDuration
-        );
-    }
-
     historyCycle() {
         if (input.isKeyPressed("ArrowUp")) {
             if (this.chatLog.length > 0) {
@@ -1069,18 +1062,18 @@ class Chat {
                 this.openChat();
             }
             if (input.isKeyPressed("Slash")) {
+                this.currentMessage = "/";
                 this.openChat();
                 this.cursorPosition = 1;
             }
-        }
 
-        if (input.isKeyPressed("Enter")) {
-            if (this.inChat) {
-                this.send();
-            }
+            // check message duration and hide if elapsed
+            const now = Date.now();
+            this.tempMessages = this.tempMessages.filter(
+                (msg) => now - msg.timestamp < this.messageDuration
+            );
         }
-
-        if (this.inChat) {
+        else {
             if (input.isKeyPressed("Escape")) this.closeChat();
 
             this.updateTyping();
@@ -1091,8 +1084,10 @@ class Chat {
                 this.showCursor = !this.showCursor;
                 this.cursorBlinkTime = 0;
             }
-        } else {
-            this.updateTempMessages();
+
+            if (input.isKeyPressed("Enter")) {
+                this.send();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description of changes
I noticed that when you press T to chat, your message box would already contain "t". To fix this, I've moved the `this.updateTyping()` call into an else statement to make sure that both the "open chat" check and the "update typing" checks can't happen simultaneously.
To maintain the behaviour for commands, I've set the message content to "/" when you press slash.

> [!NOTE]
> Somewhat unrelated, but I've removed the `updateTempMessages` method and put the code straight in the update function with a comment since the function isn't used anywhere else and I think this change makes the code easier to read. Happy to revert if you don't like it though!

## Screenshots
Before:
<img width="232" height="181" alt="2026-03-07_13-57" src="https://github.com/user-attachments/assets/4c54056d-529d-4ba1-8c6e-4cf9a4e5d215" />

After:
<img width="384" height="220" alt="image" src="https://github.com/user-attachments/assets/61ace8a2-2f86-413c-b2ad-ff9de01bb5e8" />

### Existing functionality testing:
Pressing slash still opens the chatbox with the forwardslash already inserted:
<img width="307" height="193" alt="image" src="https://github.com/user-attachments/assets/d82f7915-06ec-4516-be0f-8b5cd68a9498" />

Expired chats still show up when you're in the chatbox:
<img width="643" height="335" alt="2026-03-07_14-09" src="https://github.com/user-attachments/assets/9f2eff70-3391-407a-8fef-62ad63df7824" />

But not when you leave it:
<img width="538" height="363" alt="2026-03-07_14-10" src="https://github.com/user-attachments/assets/fef4fb88-9076-4c38-a98a-bec676cce4d5" />
