### PR TITLE
Player skin preview (options menu + inventory)

### DIFF
--- a/Client/index.html
+++ b/Client/index.html
@@ -384,14 +384,10 @@
 
                     <div class="button-space"></div>
 
-                    <div class="skin-preview-container">
-                        <canvas id="skin-preview-canvas" width="112" height="192"></canvas>
-                    </div>
                     <a onclick="backToMenu(), saveSettings()" class="btn">Done</a>
                 </div>
             </div>
     </body>
 
-    <script src="Assets/game/skinPreview.js"></script>
     <script src="menu.js"></script>
 </html>

--- a/Client/menu.css
+++ b/Client/menu.css
@@ -28,19 +28,6 @@ body {
     z-index: -2;
 }
 
-.skin-preview-container {
-    display: flex;
-    justify-content: center;
-    margin: 10px 0;
-    padding: 12px;
-    background-color: black;
-}
-
-.skin-preview-container canvas {
-    image-rendering: pixelated;
-    image-rendering: crisp-edges;
-}
-
 .button-space {
     width: 100%;
     height: 25px;

--- a/Client/menu.js
+++ b/Client/menu.js
@@ -40,7 +40,6 @@ const quickConnectButton = document.getElementById("quick-connect-btn");
 const connectButton = document.getElementById("connect-btn");
 
 const optionsContainer = document.querySelector("#options-container");
-const skinPreviewCanvas = document.getElementById("skin-preview-canvas");
 
 const musicToggleButton = document.getElementById("music-toggle-btn");
 const sfxToggleButton = document.getElementById("sfx-toggle-btn");
@@ -212,25 +211,6 @@ function loadSettings() {
     setUsernameFooter(currentSettings.username);
 
     usernameInput.value = "";
-}
-
-function updateSkinPreview() {
-    if (!skinPreviewCanvas || typeof drawSkinPreview !== "function") return;
-
-    const skinData = localStorage.getItem("playerSkin");
-    const skinSrc = skinData || "Assets/sprites/entity/steve.png";
-
-    const img = new Image();
-    img.onload = () => {
-        const ctx = skinPreviewCanvas.getContext("2d");
-        ctx.fillStyle = "black";
-        ctx.fillRect(0, 0, skinPreviewCanvas.width, skinPreviewCanvas.height);
-        const scale = 6;
-        const skinWidth = 16 * scale;
-        const baseX = (skinPreviewCanvas.width - skinWidth) / 2;
-        drawSkinPreview(ctx, img, baseX, 0, scale);
-    };
-    img.src = skinSrc;
 }
 
 loadSettings();
@@ -500,7 +480,6 @@ function uploadSkin() {
                 const skinData = event.target.result;
                 localStorage.setItem("playerSkin", skinData);
                 alert("Skin uploaded successfully!");
-                updateSkinPreview();
             };
             reader.readAsDataURL(file);
         } else {
@@ -515,7 +494,6 @@ function clearSkin() {
     if (confirm("Are you sure you want to remove your skin?")) {
         localStorage.removeItem("playerSkin");
         alert("Skin removed successfully!");
-        updateSkinPreview();
     }
 }
 
@@ -1213,7 +1191,6 @@ function gotoOptions() {
     optionsContainer.style.display = "flex";
 
     loadSettings();
-    updateSkinPreview();
 }
 
 function showMenu() {


### PR DESCRIPTION
## Description of changes
While armour is not added yet, I thought the inventory looked odd without the player so I slapped together a front-facing preview. This works both with the default Steve and with custom skins.

## Screenshots
<img width="838" height="789" alt="2026-03-07_21-10" src="https://github.com/user-attachments/assets/9e9cac10-7194-414d-87b2-35fb5651d4b0" />
<img width="839" height="796" alt="2026-03-07_21-09" src="https://github.com/user-attachments/assets/3413d209-0c3e-400a-be76-3e2cb278d6e6" />
