### PR TITLE
Fix UI flickering

### DIFF
--- a/Client/Assets/utils/renderer.js
+++ b/Client/Assets/utils/renderer.js
@@ -595,6 +595,8 @@ function drawSimpleImage({
     );
 }
 
+const imageCache = new Map();
+
 function drawImage({
     url,
     image,
@@ -615,8 +617,12 @@ function drawImage({
 
     let img = null;
     if (!image) {
-        img = new Image();
-        img.src = url;
+        if (!imageCache.has(url)) {
+            const newImg = new Image();
+            newImg.src = url;
+            imageCache.set(url, newImg);
+        }
+        img = imageCache.get(url);
     } else {
         img = image;
     }


### PR DESCRIPTION
## Description of changes
If an image URL was passed but no `image` directly, the renderer would create a new image every frame. Sometimes, the image wouldn't get created in time and so the `.complete` check would fail and the image would not be displayed for that frame.

The issue may have been less noticeable on Firefox due to a slightly different JS engine, but I can't reproduce any flickering on either browser after this change and it was happening quite badly before.

## Screenshots
<img width="1108" height="680" alt="image" src="https://github.com/user-attachments/assets/e0cec000-8a63-4515-9f7d-cecf763c7952" />
(I can't screenshot a flicker but this is proof of life)