### PR TITLE
Pause menu

### DIFF
--- a/Client/Assets/entities/player.js
+++ b/Client/Assets/entities/player.js
@@ -663,6 +663,7 @@ class Player extends Entity {
 
     interactLogic() {
         if (this.windowOpen) return;
+        if (pauseMenu?.active) return;
 
         const rightClick = input.isRightMouseButtonPressed();
 
@@ -947,6 +948,7 @@ class Player extends Entity {
 
     breakingAndPlacingLogic() {
         if (this.windowOpen) return;
+        if (pauseMenu?.active) return;
 
         if (input.isLeftMouseButtonPressed()) {
             this.playerSwing();

--- a/Client/Assets/game/pauseMenu.js
+++ b/Client/Assets/game/pauseMenu.js
@@ -1,9 +1,49 @@
 class PauseMenu {
     constructor() {
         this.active = false;
+        this.element = document.querySelector("#pause-menu");
+        this.root = document.querySelector(":root"); // for releasing the cursor
+
+        this.element.style.display = "none";
     }
 
-    setPaused(x) {
-        this.active = x;
+    setPaused(paused) {
+        this.active = paused;
+
+        if (paused) {
+            this.element.style.display = "flex";
+            this.root.style.setProperty("--drawMouse", "default");
+            if (player) {
+                player.canMove = false;
+                if (player.resetBreaking) player.resetBreaking();
+            }
+        } else {
+            this.element.style.display = "none";
+            this.root.style.setProperty("--drawMouse", "none");
+            if (player) player.canMove = true;
+        }
+    }
+
+    update() {
+        if (!input.isKeyPressed("Escape")) return;
+
+        if (this.active) {
+            this.close();
+            return;
+        }
+
+        if (chat.inChat || (player && player.windowOpen)) return;
+
+        if (player && !loadingWorld) {
+            this.open();
+        }
+    }
+
+    // not totally necessary but nice semantically
+    open() {
+        this.setPaused(true);
+    }
+    close() {
+        this.setPaused(false);
     }
 }

--- a/Client/Assets/utils/renderer.js
+++ b/Client/Assets/utils/renderer.js
@@ -114,7 +114,7 @@ function Draw(chunks, frames) {
 
     DrawBackground();
     DrawChunks(chunks);
-    if (player) {
+    if (player && !pauseMenu?.active) {
         DrawBreakAndPlaceCursor(cursorInRange);
         DrawDestroyStage();
     }
@@ -265,7 +265,7 @@ function DrawLate(chunk) {
 function AfterDraw() {
     if (player) {
         DrawUI();
-        DrawCursor();
+        if (!window.pauseMenu?.active) DrawCursor();
         if (drawCoordinates) DrawCoordinates();
     }
     if (drawCamera) DrawCamera();

--- a/Client/game.html
+++ b/Client/game.html
@@ -14,14 +14,16 @@
             <canvas id="canvas"></canvas>
             <div class="chromium-issue-1092080-workaround__overlay"></div>
 
-            <div class="pause-menu">
-                <button class="btn">Back to Game</button>
-                <div>
-                    <button class="btn" disabled>Advancements</button>
-                    <button class="btn" disabled>Statistics</button>
-                </div>
-                <button class="btn">Report Bugs</button>
-                <button class="btn">Save and Quit to Title</button>
+            <div id="pause-menu">
+                <h2 class="input-field-title" style="margin-top: -3rem; margin-bottom: 3rem; font-size: xx-large;">Game Menu</h2>
+                <button class="btn" onclick="pauseMenu.close()">Back to Game</button>
+                <!-- These will be uncommented when advancements are added -->
+                <!-- <div>
+                    <button class="btn">Advancements</button>
+                    <button class="btn">Statistics</button>
+                </div> -->
+                <a class="btn" href="https://github.com/plekiko/MinecraftJS/issues/new" target="_blank">Report Bugs</a>
+                <button class="btn" onclick="if(typeof SaveWorld==='function')SaveWorld(false);window.location.href='index.html'">Save and Quit to Title</button>
             </div>
         </div>
 
@@ -111,6 +113,7 @@
 
         <script src="Assets/entities/player.js"></script>
         <script src="Assets/game/chat.js"></script>
+        <script src="Assets/game/pauseMenu.js"></script>
         <script src="main.js"></script>
         <script src="debug.js"></script>
 

--- a/Client/main.js
+++ b/Client/main.js
@@ -9,6 +9,7 @@ let settings = {
 };
 
 chat = new Chat();
+pauseMenu = new PauseMenu();
 
 function waitForTexturePack() {
     return new Promise((resolve) => {
@@ -136,6 +137,7 @@ function updateGame() {
 
     if (player) cursorBlockLogic();
     if (hotbar) hotbar.update();
+    if (pauseMenu) pauseMenu.update();
     if (chat) chat.update();
     camera.update(player);
     dayNightCycle();
@@ -210,6 +212,15 @@ function updateArray(array, deltaTime) {
 }
 
 function cursorBlockLogic() {
+    if (pauseMenu?.active) {
+        cursorInRange = false;
+        if (player) {
+            player.hoverBlock = null;
+            player.hoverWall = null;
+        }
+        return;
+    }
+
     const cursorDistance = Math.floor(
         Vector2.Distance(
             player.position,

--- a/Client/style.css
+++ b/Client/style.css
@@ -77,8 +77,19 @@ body {
     border-radius: 5px;
 }
 
-.pause-menu {
+#pause-menu .pause-menu-title {
+    color: white;
+    font-family: "Pixel";
+    font-size: 2rem;
+    margin-bottom: 2rem;
+}
+
+#pause-menu {
     position: fixed;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     top: 0;
     left: 0;
     width: 100%;
@@ -86,12 +97,10 @@ body {
     margin: 0;
     padding: 0;
     background-color: rgba(0, 0, 0, 0.5);
-    z-index: 9999;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+    z-index: 1000;
 
+    /* To stack buttons horizontally */
+    /* (for advancements which are currently hidden) */
     div {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
## Description of changes
Added a pause menu when you press Escape. Currently, it does not pause the game-loop as that will require extra logic for multiplayer so I've just left it out of singleplayer too for now. Pausing just freezes player movement and interaction and releases the cursor.

- "Back to Game" just closes the pause menu. You can also press Escape again to toggle out of the menu.
- "Report Bugs" takes the user to the "New Issue" page on this GitHub repo in a new tab.
- "Save and Quit to Title" saves the world and navigates the user back to the main menu.

## Screenshots
<img width="687" height="449" alt="image" src="https://github.com/user-attachments/assets/fe6e2394-0d2c-4f6f-83d7-00058fb7268e" />
