### PR TITLE
Fix texture packs not loading

### DIFF
--- a/Client/Assets/utils/texturePackLoader.js
+++ b/Client/Assets/utils/texturePackLoader.js
@@ -143,10 +143,12 @@ async function loadTexturePack() {
             return;
         }
 
-        const base64Data = texturePackData.replace(
-            "data:application/x-zip-compressed;base64,",
-            ""
-        );
+        const base64Data =
+            typeof texturePackData === "string" &&
+            texturePackData.startsWith("data:") &&
+            texturePackData.includes(",")
+                ? texturePackData.slice(texturePackData.indexOf(",") + 1)
+                : texturePackData;
 
         const zip = await JSZip.loadAsync(base64Data, { base64: true });
         texturePackZip = zip;

--- a/Client/menu.js
+++ b/Client/menu.js
@@ -412,14 +412,14 @@ function uploadTexturePack() {
                 ldb.set(`texturePack_${packId}`, texturePackData);
 
                 try {
-                    const base64Data = texturePackData.startsWith(
-                        "data:application/x-zip-compressed;`base64`,"
-                    )
-                        ? texturePackData.replace(
-                              "data:application/x-zip-compressed;base64,",
-                              ""
-                          )
-                        : texturePackData;
+                    const base64Data =
+                        typeof texturePackData === "string" &&
+                        texturePackData.startsWith("data:") &&
+                        texturePackData.includes(",")
+                            ? texturePackData.slice(
+                                  texturePackData.indexOf(",") + 1
+                              )
+                            : texturePackData;
                     const zip = await JSZip.loadAsync(base64Data, {
                         base64: true,
                     });


### PR DESCRIPTION
## Description of changes
MIME zip data types are formatted differently from browser-to-browser, and can differ based on OS even if the browser is the same. Improved hardcoded "replace" for the data blob so that all type formats are supported.

Tested on Linux and MacOS (both Chrome).
I don't have a Windows machine to test on so feel free to pull this branch down and test that before merging. No reason it shouldn't work, though.

## Screenshots
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/b4cea6ee-bc55-4db1-b4a3-9032af4b05ce" />
