### PR TITLE
Fix creeper death

### DIFF
--- a/Client/Assets/entities/mobs/cow.js
+++ b/Client/Assets/entities/mobs/cow.js
@@ -63,7 +63,7 @@ class Cow extends Mob {
             positional: true,
             origin: this.position,
         });
-        removeEntity(this);
+        this.world.removeEntity(this);
     }
 
     tickUpdate() {

--- a/Client/Assets/entities/mobs/creeper.js
+++ b/Client/Assets/entities/mobs/creeper.js
@@ -74,7 +74,7 @@ class Creeper extends Mob {
             this.fuse--;
             if (this.fuse <= 0) {
                 this.explode();
-                removeEntity(this);
+                this.world.removeEntity(this);
             } else if (this.body) {
                 // Pulse white: 50% of each cycle show flash
                 const phase =
@@ -116,7 +116,7 @@ class Creeper extends Mob {
     dieEvent() {
         this.dropLoot();
         playPositionalSound(this.position, "mobs/creeper/death.ogg");
-        removeEntity(this);
+        this.world.removeEntity(this);
     }
 
     interact(player, item) {}


### PR DESCRIPTION
Super simple, these removeEntity calls were just missed during the world separation refactor, causing creepers to endlessly plow through the world upon exploding