### PR TITLE
Fix interface selection

### DIFF
--- a/Client/Assets/utils/drawHelpers.js
+++ b/Client/Assets/utils/drawHelpers.js
@@ -19,11 +19,12 @@ export function drawSimpleImage({
 
     ctx.globalAlpha = opacity;
 
-    const shouldCrop = crop.width > 0 && crop.height > 0;
-    const sourceWidth = shouldCrop ? crop.width : image.width;
-    const sourceHeight = shouldCrop ? crop.height : image.height;
-    const sourceX = shouldCrop ? crop.x : 0;
-    const sourceY = shouldCrop ? crop.y : 0;
+    const safeCrop = crop ?? { x: 0, y: 0, width: 0, height: 0 };
+    const shouldCrop = safeCrop.width > 0 && safeCrop.height > 0;
+    const sourceWidth = shouldCrop ? safeCrop.width : image.width;
+    const sourceHeight = shouldCrop ? safeCrop.height : image.height;
+    const sourceX = shouldCrop ? safeCrop.x : 0;
+    const sourceY = shouldCrop ? safeCrop.y : 0;
 
     const drawWidth = width || sourceWidth * scale;
     const drawHeight = height || sourceHeight * scale;

--- a/Client/Assets/utils/renderer.js
+++ b/Client/Assets/utils/renderer.js
@@ -92,7 +92,7 @@ export function hexToRgb(hex) {
 }
 
 export function mouseOverPosition(x, y, sizeX, sizeY, world = false) {
-    const mousePos = runtime.world
+    const mousePos = world
         ? input.getMouseWorldPosition()
         : input.getMousePosition();
 


### PR DESCRIPTION
Erroneous change from world to runtime.world during refactor caused screen-space coords to be incorrect for cursor in interface. Stopped you interacting with inventory, chests, crafting tables, etc.

Also fixed crash I found where cropping could happen before the image loaded, such as when a mob spawns straight into sunlight and sets on fire. Added guard so the crop values fallback to zeroes.