### PR TITLE
Add shared npm ci to github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ jobs:
               with:
                   node-version: "24"
 
+            - name: Install Shared dependencies
+              working-directory: ./Shared
+              run: npm ci
+
             - name: Install Client dependencies
               working-directory: ./Client
               run: npm ci

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ## Local Development
 
 ### Option 1 - Node.js
-To get set up, run `npm install` in both the Client and Server directories.
+To get set up, run `npm install` in the Shared, Client, and Server directories.
 
 From the Client directory, run `npm run dev` to start the Vite dev server on `localhost:3000` (hot module reload for the client).
 


### PR DESCRIPTION
Deploy failed after merging the "Shared" refactor #47 because I forgot to add installing it to the action